### PR TITLE
Refactor dispatcher return type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/TomChv/jsonrpc2
 
 go 1.17
 
+require github.com/PtitLuca/go-dispatcher v1.0.1
+
 require (
-	github.com/PtitLuca/go-dispatcher v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/PtitLuca/go-dispatcher v1.0.0 h1:ci6Rfw0BP8ANSaxyPe3wzoBEPYPmfdvB+31q+7uUjzQ=
 github.com/PtitLuca/go-dispatcher v1.0.0/go.mod h1:LnUEx7yU8cM//F/NT31Fb+cMoDffuCJLKIOi5opAUfk=
+github.com/PtitLuca/go-dispatcher v1.0.1 h1:vEd9j8f/dAD8k0O3E4Eaq0ndCWG95C1NXsjmnRIGSt0=
+github.com/PtitLuca/go-dispatcher v1.0.1/go.mod h1:LnUEx7yU8cM//F/NT31Fb+cMoDffuCJLKIOi5opAUfk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,31 +19,28 @@ func (ms *mockInvalidService) MethodInvalidNoReturnType() {}
 
 type mockInvalidService2 struct{}
 
-func (ms *mockInvalidService2) MethodInvalidIncompleteReturnType() *Response {
+func (ms *mockInvalidService2) MethodInvalidIncompleteReturnType() interface{} {
 	return nil
 }
 
 type mockService struct{}
 
-func (ms mockService) MethodEmptyArgs() (*Response, *RpcError) {
+func (ms mockService) MethodEmptyArgs() (interface{}, error) {
 	return nil, nil
 }
 
-func (ms mockService) MethodWithArg(str string) (*Response, *RpcError) {
-	return common.NewResponse("0").SetResult(str), nil
+func (ms mockService) MethodWithArg(str string) (string, error) {
+	return str, nil
 }
 
-func (ms mockService) MethodWithArgs(str string, num int64) (*Response, *RpcError) {
-	return common.NewResponse("0").SetResult(struct {
-		Str string
-		Num int64
-	}{
-		Str: str,
-		Num: num,
-	}), nil
+func (ms mockService) MethodWithArgs(str string, num int64) (map[string]interface{}, *RpcError) {
+	return map[string]interface{}{
+		"str": str,
+		"num": num,
+	}, nil
 }
 
-func (ms mockService) MethodWithComplexArgs(str []string, num int64, b bool, obj interface{}) (*Response, *RpcError) {
+func (ms mockService) MethodWithComplexArgs(str []string, num int64, b bool, obj interface{}) (*Response, error) {
 	return common.NewResponse("0").SetResult(struct {
 		Str    []string
 		Num    int64

--- a/server/validator.go
+++ b/server/validator.go
@@ -10,17 +10,13 @@ var (
 )
 
 // validateService ensure that each public methods of the service is compliant
-// with the JSON RPC 2.0 response type : (Response, RpcError).
+// with the type : (interface{}, error).
 //
 // It uses reflect to loop though each public methods of the service
 // Then it verifies that method has the same return type than expected.
 //
 // If service is compliant, validateService return true, else false.
 func validateService(service interface{}) bool {
-	expectedSignatureTypes := []reflect.Type{
-		reflect.TypeOf(&Response{}),
-		reflect.TypeOf(&RpcError{}),
-	}
 	st := reflect.TypeOf(service)
 
 	for i := 0; i < st.NumMethod(); i++ {
@@ -32,10 +28,8 @@ func validateService(service interface{}) bool {
 			return false
 		}
 
-		for j := 0; j < st.Method(i).Func.Type().NumOut(); j++ {
-			if !st.Method(i).Func.Type().Out(j).AssignableTo(expectedSignatureTypes[j]) {
-				return false
-			}
+		if !st.Method(i).Func.Type().Out(1).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
Since server.ServeHTTP already wrap response in a RpcService and RpcError.
To avoid duplication, this commit simplifies the expected return type of
RPCs registered in a service.

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>