### PR TITLE
Handle batch request with concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/TomChv/jsonrpc2
 
 go 1.17
 
-require github.com/PtitLuca/go-dispatcher v1.0.3
+require (
+	github.com/PtitLuca/go-dispatcher v1.0.3
+	github.com/stretchr/testify v1.7.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,3 @@
-github.com/PtitLuca/go-dispatcher v1.0.0 h1:ci6Rfw0BP8ANSaxyPe3wzoBEPYPmfdvB+31q+7uUjzQ=
-github.com/PtitLuca/go-dispatcher v1.0.0/go.mod h1:LnUEx7yU8cM//F/NT31Fb+cMoDffuCJLKIOi5opAUfk=
-github.com/PtitLuca/go-dispatcher v1.0.1 h1:vEd9j8f/dAD8k0O3E4Eaq0ndCWG95C1NXsjmnRIGSt0=
-github.com/PtitLuca/go-dispatcher v1.0.1/go.mod h1:LnUEx7yU8cM//F/NT31Fb+cMoDffuCJLKIOi5opAUfk=
-github.com/PtitLuca/go-dispatcher v1.0.2 h1:arHPAfbTLX3R+XqCE+U9tURItJsI7/ltP5NOdJpfZiA=
-github.com/PtitLuca/go-dispatcher v1.0.2/go.mod h1:LnUEx7yU8cM//F/NT31Fb+cMoDffuCJLKIOi5opAUfk=
 github.com/PtitLuca/go-dispatcher v1.0.3 h1:tp6jy81n5xFsDpdgqQFkLUmoBwo44wlzS+ShTGWNyxU=
 github.com/PtitLuca/go-dispatcher v1.0.3/go.mod h1:LnUEx7yU8cM//F/NT31Fb+cMoDffuCJLKIOi5opAUfk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -13,6 +7,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parser/batch.go
+++ b/parser/batch.go
@@ -1,0 +1,37 @@
+package parser
+
+import (
+	"encoding/json"
+
+	"github.com/TomChv/jsonrpc2/common"
+	"github.com/TomChv/jsonrpc2/validator"
+)
+
+// Batch parse an array of byte to convert it into an array of request and
+// errors
+// This function do not fail if any request isn't valid, it will add it to
+// errors array
+// To differentiate parsing error from invalid request, boolean is sent as
+// first return value
+func Batch(body []byte) (bool, []*common.Request, []error) {
+	var reqs []common.Request
+
+	if err := json.Unmarshal(body, &reqs); err != nil {
+		return false, nil, nil
+	}
+
+	res := []*common.Request{}
+	var errs []error
+
+	for _, req := range reqs {
+		req := req
+		if err := validator.JsonRPCRequest(&req); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		// Have an issue if append with &req
+		res = append(res, &req)
+	}
+
+	return true, res, errs
+}

--- a/parser/batch_test.go
+++ b/parser/batch_test.go
@@ -1,0 +1,89 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/TomChv/jsonrpc2/common"
+	"github.com/TomChv/jsonrpc2/validator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatch(t *testing.T) {
+	testCases := []struct {
+		name           string
+		body           []byte
+		success        bool
+		expectedResult []*common.Request
+		expectedError  []error
+	}{
+		{
+			name:           "Empty array",
+			body:           []byte(`[]`),
+			success:        true,
+			expectedResult: []*common.Request{},
+			expectedError:  nil,
+		},
+		{
+			name:           "Simple request [Only Method]",
+			body:           []byte(`[{"jsonrpc": "2.0", "method": "/test"}]`),
+			success:        true,
+			expectedResult: []*common.Request{common.NewRequest().SetMethod("/test")},
+			expectedError:  nil,
+		},
+		{
+			name:           "Simple request [Only Method, Invalid json rpc version]",
+			body:           []byte(`[{"jsonrpc": "2.0", "method": "/test"},{"jsonrpc": "3.0","method": "/test"}]`),
+			success:        true,
+			expectedResult: []*common.Request{common.NewRequest().SetMethod("/test")},
+			expectedError:  []error{validator.ErrInvalidJsonVersion},
+		},
+		{
+			name:           "Simple request [Missing method, Invalid json rpc version]",
+			body:           []byte(`[{"jsonrpc": "2.0", "id": 0},{"jsonrpc": "3.0","method": "/test"}]`),
+			success:        true,
+			expectedResult: []*common.Request{},
+			expectedError:  []error{validator.ErrMissingMethod, validator.ErrInvalidJsonVersion},
+		},
+		{
+			name:           "Simple request [Invalid json rpc version, Missing method]",
+			body:           []byte(`[{"jsonrpc": "3.0","method": "/test"},{"jsonrpc": "2.0", "id": 0}]`),
+			success:        true,
+			expectedResult: []*common.Request{},
+			expectedError:  []error{validator.ErrInvalidJsonVersion, validator.ErrMissingMethod},
+		},
+		{
+			name:    "Batch request [Only Method, Missing method, String identifier]",
+			body:    []byte(`[{"jsonrpc": "2.0", "method": "/test"},{"jsonrpc": "2.0", "id": 0},{"jsonrpc": "2.0", "method": "/test", "id": "fake_id"}]`),
+			success: true,
+			expectedResult: []*common.Request{
+				common.NewRequest().SetMethod("/test"),
+				common.NewRequest().SetMethod("/test").SetID("fake_id"),
+			},
+			expectedError: []error{validator.ErrMissingMethod},
+		},
+		{
+			name:    "Batch request [Only Method, Missing method, String identifier, With param struct]",
+			body:    []byte(`[{"jsonrpc": "2.0", "method": "/test"},{"jsonrpc": "2.0", "id": 0},{"jsonrpc": "2.0", "method": "/test", "id": "fake_id"},{"jsonrpc": "2.0", "method": "/test", "params": {"foo": "bar", "baz": 4 }}]`),
+			success: true,
+			expectedResult: []*common.Request{
+				common.NewRequest().SetMethod("/test"),
+				common.NewRequest().SetMethod("/test").SetID("fake_id"),
+				common.NewRequest().SetMethod("/test").SetParams(map[string]interface{}{
+					"foo": "bar",
+					"baz": float64(4),
+				}),
+			},
+			expectedError: []error{validator.ErrMissingMethod},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, res, err := Batch(tt.body)
+
+			assert.Equal(t, tt.success, ok)
+			assert.Equal(t, tt.expectedResult, res)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}

--- a/server/sendBatch.go
+++ b/server/sendBatch.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (s *JsonRPC2) sendBatch(res []*Response, w http.ResponseWriter) error {
+	data, err := json.Marshal(res)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This commit adds management of batch request in a concurrency way for
optimization purpose.
It also adds a Batch function in the parser to correctly parse it
Everything come with unit test.

Resolves #7 

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>