### PR TITLE
Update server errors to take an error as additional data

### DIFF
--- a/server/error.go
+++ b/server/error.go
@@ -3,57 +3,57 @@ package server
 import "github.com/TomChv/jsonrpc2/common"
 
 // ParsingError when invalid JSON was received by the server
-func ParsingError(data interface{}) *common.RpcError {
+func ParsingError(err error) *common.RpcError {
 	return &common.RpcError{
 		Code:    -32700,
 		Message: "Parse error",
-		Data:    data,
+		Data:    err.Error(),
 	}
 }
 
 // InvalidRequestError when the JSON sent is not a valid Request object
-func InvalidRequestError(data interface{}) *common.RpcError {
+func InvalidRequestError(err error) *common.RpcError {
 	return &common.RpcError{
 		Code:    -32600,
 		Message: "Invalid Request",
-		Data:    data,
+		Data:    err.Error(),
 	}
 }
 
 // MethodNotFoundError when the method does not exist / is not available
-func MethodNotFoundError(data interface{}) *common.RpcError {
+func MethodNotFoundError(err error) *common.RpcError {
 	return &common.RpcError{
 		Code:    -32601,
 		Message: "Method not found",
-		Data:    data,
+		Data:    err.Error(),
 	}
 }
 
 // InvalidParamsError for invalid method parameter(s)
-func InvalidParamsError(data interface{}) *common.RpcError {
+func InvalidParamsError(err error) *common.RpcError {
 	return &common.RpcError{
 		Code:    -32602,
 		Message: "Invalid params",
-		Data:    data,
+		Data:    err.Error(),
 	}
 }
 
 // InternalError  for internal JSON-RPC error
-func InternalError(data interface{}) *common.RpcError {
+func InternalError(err error) *common.RpcError {
 	return &common.RpcError{
 		Code:    -32603,
 		Message: "Internal error",
-		Data:    data,
+		Data:    err.Error(),
 	}
 }
 
 // CustomError reserved for implementation-defined server-errors
 // Code must be bound with the range -32000 and -32099 according to official
 // JSON-RPC 2.0 specification.
-func CustomError(code int64, data interface{}) *common.RpcError {
+func CustomError(code int64, err error) *common.RpcError {
 	return &common.RpcError{
 		Code:    code,
 		Message: "Server error",
-		Data:    data,
+		Data:    err.Error(),
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -53,26 +53,26 @@ func (s *JsonRPC2) Register(namespace string, service interface{}) error {
 // Implement HTTP interface to listen and response to incoming HTTP request
 func (s *JsonRPC2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := validator.HTTPRequest(r); err != nil {
-		_ = common.NewResponse(nil).SetError(InvalidRequestError(err.Error())).Send(w)
+		_ = common.NewResponse(nil).SetError(InvalidRequestError(err)).Send(w)
 		return
 	}
 
 	isBatch, err := validator.IsBatchRequest(r)
 	if err != nil {
-		_ = common.NewResponse(nil).SetError(ParsingError(err.Error())).Send(w)
+		_ = common.NewResponse(nil).SetError(ParsingError(err)).Send(w)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		_ = common.NewResponse(nil).SetError(ParsingError(err.Error())).Send(w)
+		_ = common.NewResponse(nil).SetError(ParsingError(err)).Send(w)
 		return
 	}
 
 	if !isBatch {
 		req, err := parser.Request(body)
 		if err != nil {
-			res := common.NewResponse(nil).SetError(InvalidRequestError(err.Error()))
+			res := common.NewResponse(nil).SetError(InvalidRequestError(err))
 			if req != nil && req.ID != nil {
 				res.SetID(req.ID)
 			}
@@ -91,9 +91,9 @@ func (s *JsonRPC2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reqs, err := parser.Batch(body)
 	if err != nil {
 		if errors.Is(err, parser.ErrEmptyBatch) {
-			_ = common.NewResponse(nil).SetError(InvalidRequestError(err.Error())).Send(w)
+			_ = common.NewResponse(nil).SetError(InvalidRequestError(err)).Send(w)
 		} else {
-			_ = common.NewResponse(nil).SetError(ParsingError(err.Error())).Send(w)
+			_ = common.NewResponse(nil).SetError(ParsingError(err)).Send(w)
 		}
 		return
 	}
@@ -114,19 +114,19 @@ func (s *JsonRPC2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			err := json.Unmarshal(rawR, &req)
 			if err != nil {
-				r = common.NewResponse(nil).SetError(InvalidRequestError(err.Error()))
+				r = common.NewResponse(nil).SetError(InvalidRequestError(err))
 				batchRes.Append(r)
 				return
 			}
 
 			if req.JsonRpc == "" {
-				r = common.NewResponse(nil).SetError(InvalidRequestError(validator.ErrInvalidJsonVersion.Error()))
+				r = common.NewResponse(nil).SetError(InvalidRequestError(validator.ErrInvalidJsonVersion))
 				batchRes.Append(r)
 				return
 			}
 
 			if err := validator.JsonRPCRequest(&req); err != nil {
-				r = common.NewResponse(nil).SetError(InvalidRequestError(err.Error()))
+				r = common.NewResponse(nil).SetError(InvalidRequestError(err))
 				if req.ID != nil {
 					r.SetID(req.ID)
 				}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -203,25 +203,25 @@ func TestJsonRPC2_ServeHTTP_Single(t *testing.T) {
 			name:             "call unknown method",
 			success:          false,
 			req:              common.NewRequest().SetID("fake_id").SetMethod("unknown"),
-			expectedResponse: common.NewResponse("fake_id").SetError(MethodNotFoundError(dispatcher.ErrNonExistentService.Error())),
+			expectedResponse: common.NewResponse("fake_id").SetError(MethodNotFoundError(dispatcher.ErrNonExistentService)),
 		},
 		{
 			name:             "call with empty body",
 			success:          false,
 			req:              common.NewRequest(),
-			expectedResponse: common.NewResponse(nil).SetError(InvalidRequestError(validator.ErrMissingMethod.Error())),
+			expectedResponse: common.NewResponse(nil).SetError(InvalidRequestError(validator.ErrMissingMethod)),
 		},
 		{
 			name:             "call with missing method and identifier",
 			success:          true,
 			req:              common.NewRequest().SetID("fake_id"),
-			expectedResponse: common.NewResponse("fake_id").SetError(InvalidRequestError(validator.ErrMissingMethod.Error())),
+			expectedResponse: common.NewResponse("fake_id").SetError(InvalidRequestError(validator.ErrMissingMethod)),
 		},
 		{
 			name:             "call with missing method and invalid identifier",
 			success:          true,
 			req:              common.NewRequest().SetID(false),
-			expectedResponse: common.NewResponse(nil).SetError(InvalidRequestError(validator.ErrInvalidIdentifierType.Error())),
+			expectedResponse: common.NewResponse(nil).SetError(InvalidRequestError(validator.ErrInvalidIdentifierType)),
 		},
 	}
 
@@ -287,7 +287,7 @@ func TestJsonRPC2_ServeHTTP_Batch(t *testing.T) {
 				common.NewRequest().SetID("fake_id").SetMethod("unknown"),
 			},
 			expectedResponses: []*Response{
-				common.NewResponse("fake_id").SetError(MethodNotFoundError(dispatcher.ErrNonExistentService.Error())),
+				common.NewResponse("fake_id").SetError(MethodNotFoundError(dispatcher.ErrNonExistentService)),
 				common.NewResponse("fake_id").SetResult("foo"),
 			},
 		},
@@ -316,7 +316,7 @@ func TestJsonRPC2_ServeHTTP_Batch(t *testing.T) {
 				common.NewRequest().SetID("sleep_fast").SetMethod("mock_methodWithSleep").SetParams([]int64{1}),
 			},
 			expectedResponses: []*Response{
-				common.NewResponse("fake_id").SetError(MethodNotFoundError(dispatcher.ErrNonExistentService.Error())),
+				common.NewResponse("fake_id").SetError(MethodNotFoundError(dispatcher.ErrNonExistentService)),
 				common.NewResponse("sleep_fast").SetResult("slept well"),
 				common.NewResponse("sleep_medium").SetResult("slept well"),
 				common.NewResponse("sleep_long").SetResult("slept well"),
@@ -340,7 +340,7 @@ func TestJsonRPC2_ServeHTTP_Batch(t *testing.T) {
 				common.NewRequest().SetID(0),
 			},
 			expectedResponses: []*Response{
-				common.NewResponse(float64(0)).SetError(InvalidRequestError(validator.ErrMissingMethod.Error())),
+				common.NewResponse(float64(0)).SetError(InvalidRequestError(validator.ErrMissingMethod)),
 			},
 		},
 		{
@@ -353,7 +353,7 @@ func TestJsonRPC2_ServeHTTP_Batch(t *testing.T) {
 				common.NewRequest().SetID("fake_id_args").SetMethod("mock_methodWithArgs").SetParams([]interface{}{"foo", -1}),
 			},
 			expectedResponses: []*Response{
-				common.NewResponse(float64(0)).SetError(InvalidRequestError(validator.ErrMissingMethod.Error())),
+				common.NewResponse(float64(0)).SetError(InvalidRequestError(validator.ErrMissingMethod)),
 				common.NewResponse("fake_id_args").SetResult(map[string]interface{}{
 					"str": "foo",
 					"num": float64(-1),


### PR DESCRIPTION
These changes clean error management and simplify usability.
Instead, to wrap an `error` in `JsonRPC` error, you had to do

```golang
InternalServerError(err.Error())
```
Now you can directly forward `err`.

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>